### PR TITLE
NEW Add timestamp to cron output

### DIFF
--- a/code/controllers/CronTaskController.php
+++ b/code/controllers/CronTaskController.php
@@ -127,10 +127,11 @@ class CronTaskController extends Controller
         if ($this->quiet) {
             return;
         }
+        $timestamp = DBDatetime::now()->Format('Y-m-d H:i:s');
         if (Director::is_cli()) {
-            echo $message . PHP_EOL;
+            echo $timestamp . ' - ' . $message . PHP_EOL;
         } else {
-            echo Convert::raw2xml($message) . '<br />' . PHP_EOL;
+            echo Convert::raw2xml($timestamp . ' - ' . $message) . '<br />' . PHP_EOL;
         }
     }
 }


### PR DESCRIPTION
This adds a timestamp to the cron output which can be useful when looking through logs that may be stored from the cron runner output.