### PR TITLE
FIX Class name and remapping for SS4

### DIFF
--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -1,0 +1,6 @@
+---
+Name: crontasklegacy
+---
+SilverStripe\ORM\DatabaseAdmin:
+  classname_value_remapping:
+    CronTaskStatus: SilverStripe\CronTask\CronTaskStatus

--- a/src/CronTaskStatus.php
+++ b/src/CronTaskStatus.php
@@ -18,6 +18,11 @@ class CronTaskStatus extends DataObject
 {
     /**
      * {@inheritDoc}
+     */
+    private static $table_name = 'CronTaskStatus';
+
+    /**
+     * {@inheritDoc}
      * @var array
      */
     private static $db = array(


### PR DESCRIPTION
* Fixes database table being created called "SilverStripe\CronTask\CronTaskStatus"