### PR TITLE
Add quiet option for cron - suppresses normal output to allow monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ The content of that file should be:
 This will run every minute as the www-data user and check if there are any
 outstanding tasks that needs to be executed.
 
+By default this will output information on which cron tasks are being executed -  
+if you are monitoring cron output for errors you can suppress this output by 
+adding quiet=1 - for example
+
+```
+MAILTO=admin@example.com
+* * * * * www-data /usr/bin/php /path/to/silverstripe/docroot/framework/cli-script.php dev/cron quiet=1
+```
+
 **Warning**: Observe that the crontask module doesn't do any checking. If 
 you define a task to run every 5 mins it will run every 5 minutes whether it 
 completed or not (as a normal cron would). If the run time of an 'every-5-minutes' 

--- a/code/controllers/CronTaskController.php
+++ b/code/controllers/CronTaskController.php
@@ -48,6 +48,9 @@ class CronTaskController extends Controller
         if (!Director::is_cli() && !Permission::check("ADMIN")) {
             Security::permissionFailure();
         }
+
+        // set quiet flag based on CLI parameter
+        $this->setQuiet( $this->getRequest()->getVar('quiet') );
     }
 
     /**

--- a/tests/CronTaskControllerTest.php
+++ b/tests/CronTaskControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class CronTaskControllerTest extends SapphireTest
+class CronTaskControllerTest extends FunctionalTest
 {
 
     protected $usesDatabase = true;
@@ -102,8 +102,37 @@ class CronTaskControllerTest extends SapphireTest
         $this->assertFalse($runner->quiet);
     }
 
-}
+    function testQuietArgument() {
+     $this->loginWithPermission('ADMIN');
 
+     // normal cron output includes the current date/time - we check for that
+     // cron uses its own output(), so the ss_httpresponse we get from $this->get() is blank
+     // so we use output buffering instead
+
+     // we expect a date in the output
+     ob_start();
+     $this->get('dev/cron');
+     $output = ob_get_contents();
+     ob_end_clean();
+     $this->assertContains(SS_Datetime::now()->Format('Y-m-d'), $output);
+
+     // same with quiet=1
+     ob_start();
+     $this->get('dev/cron?quiet=0');
+     $output = ob_get_contents();
+     ob_end_clean();
+     $this->assertContains(SS_Datetime::now()->Format('Y-m-d'), $output);
+
+     // with quiet=0 we expect no output
+     ob_start();
+     $this->get('dev/cron?quiet=1');
+     $output = ob_get_contents();
+     ob_end_clean();
+     $this->assertEquals('', $output);
+          
+  }
+    
+}
 
 class CronTaskTest_TestCron implements TestOnly, CronTask
 {

--- a/tests/CronTaskControllerTest.php
+++ b/tests/CronTaskControllerTest.php
@@ -102,35 +102,27 @@ class CronTaskControllerTest extends FunctionalTest
         $this->assertFalse($runner->quiet);
     }
 
-    function testQuietArgument() {
-     $this->loginWithPermission('ADMIN');
-
-     // normal cron output includes the current date/time - we check for that
-     // cron uses its own output(), so the ss_httpresponse we get from $this->get() is blank
-     // so we use output buffering instead
-
-     // we expect a date in the output
-     ob_start();
-     $this->get('dev/cron');
-     $output = ob_get_contents();
-     ob_end_clean();
-     $this->assertContains(SS_Datetime::now()->Format('Y-m-d'), $output);
-
-     // same with quiet=1
-     ob_start();
-     $this->get('dev/cron?quiet=0');
-     $output = ob_get_contents();
-     ob_end_clean();
-     $this->assertContains(SS_Datetime::now()->Format('Y-m-d'), $output);
-
-     // with quiet=0 we expect no output
-     ob_start();
-     $this->get('dev/cron?quiet=1');
-     $output = ob_get_contents();
-     ob_end_clean();
-     $this->assertEquals('', $output);
-          
-  }
+    // normal cron output includes the current date/time - we check for that
+    // the exact output here could vary depending on what other modules are installed
+    function testDefaultQuietFlagOutput()
+    {
+        $this->loginWithPermission('ADMIN');
+        $this->expectOutputRegex('#'.SS_Datetime::now()->Format('Y-m-d').'#');
+        $this->get('dev/cron');
+    }
+    function testQuietFlagOffOutput()
+    {
+        $this->loginWithPermission('ADMIN');
+        $this->expectOutputRegex('#'.SS_Datetime::now()->Format('Y-m-d').'#');
+        $this->get('dev/cron?quiet=0');
+    }
+    // with the flag set we want no output
+    function testQuietFlagOnOutput()
+    {
+        $this->loginWithPermission('ADMIN');
+        $this->expectOutputString('');
+        $this->get('dev/cron?quiet=1');
+    }
     
 }
 


### PR DESCRIPTION
This is relevant if you're using MAILTO= in your server cron setup to watch for crashes - in that case generally you want cron to have no normal output 