### PR TITLE
Update readme examples, remove _config.php, use Injector to create CronTask implementors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 /tests export-ignore
 /.travis.yml export-ignore
+/.scrutinizer.yml export-ignore
+/phpunit.xml.dist export-ignore
+/codecov.yml export-ignore

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ most common way is by adding a file to the `/etc/cron.d/` directory.
 First find the correct command to execute, for example:
 
 ```
-/usr/bin/php /path/to/silverstripe/docroot/vendor/silverstripe/framework/cli-script.php dev/cron
+/usr/bin/php /path/to/silverstripe/docroot/vendor/bin/sake dev/cron
 ```
 
 Then find out which user the webserver is running on, for example `www-data`.
@@ -113,7 +113,7 @@ sudo vim /etc/cron.d/silverstripe-crontask
 The content of that file should be:
 
 ```
-* * * * * www-data /usr/bin/php /path/to/silverstripe/docroot/vendor/silverstripe/framework/cli-script.php dev/cron
+* * * * * www-data /usr/bin/php /path/to/silverstripe/docroot/vendor/bin/sake dev/cron
 ```
 
 This will run every minute as the www-data user and check if there are any

--- a/README.md
+++ b/README.md
@@ -27,22 +27,24 @@ CMS-driven scheduler
 -------------------------------
 
 If you are looking for CMS-controllable scheduler, please check out
-the [queuedjobs module](https://github.com/silverstripe-australia/silverstripe-queuedjobs/).
+the [queuedjobs module](https://github.com/symbiote/silverstripe-queuedjobs/).
 Here are some examples of how to implement recurring jobs with that module:
 
-* [GenerateGoogleSitemapJob](https://github.com/silverstripe-australia/silverstripe-queuedjobs/blob/570bae301c09d4c4367144be260a7213341a0020/code/jobs/GenerateGoogleSitemapJob.php#L184)
-* [LDAPMemberSyncJob](https://github.com/silverstripe/silverstripe-activedirectory/blob/master/code/jobs/LDAPMemberSyncJob.php#L52)
+* [GenerateGoogleSitemapJob](https://github.com/symbiote/silverstripe-queuedjobs/blob/570bae301c09d4c4367144be260a7213341a0020/code/jobs/GenerateGoogleSitemapJob.php#L184)
+* [LDAPMemberSyncJob](https://github.com/silverstripe/silverstripe-ldap/blob/2857c2d7ff34c2b0ca9fdd43ed657799d2224631/src/Jobs/LDAPMemberSyncJob.php#L88)
 
 Installing
 ----------
 
 Add the following to your project's composer.json:
 
-	{
-		"require": {
-			"silverstripe/crontask": "*"
-		}
-	}
+```json
+{
+    "require": {
+        "silverstripe/crontask": "^2.0"
+    }
+}
+```
 
 Run `composer update` (this will also install needed 3rd party libs in ./vendor)
 
@@ -51,33 +53,41 @@ Usage
 
 Implement the `CronTask` interface on a new or already existing class:
 
-	class TestCron implements CronTask {
+```php
+use SilverStripe\CronTask\Interfaces\CronTask;
 
-		/**
-		 * run this task every 5 minutes
-		 *
-		 * @return string
-		 */
-		public function getSchedule() {
-			return "*/5 * * * *";
-		}
+class TestCron implements CronTask
+{
+    /**
+     * run this task every 5 minutes
+     *
+     * @return string
+     */
+    public function getSchedule()
+    {
+        return "*/5 * * * *";
+    }
 
-		/**
-		 *
-		 * @return void
-		 */
-		public function process() {
-			echo 'hello';
-		}
-	}
+    /**
+     *
+     * @return void
+     */
+    public function process()
+    {
+        echo 'hello';
+    }
+}
+```
 
-Run `./framework/sake dev/build flush=1` to make SilverStripe aware of the new
+Run `vendor/bin/sake dev/build flush=1` to make SilverStripe aware of the new
 module.
 
 Then execute the crontask controller, it's preferable you do this via the CLI
 since that is how the server will execute it.
 
-	./framework/sake dev/cron
+```
+vendor/bin/sake dev/cron
+```
 
 Server configuration
 --------------------
@@ -89,7 +99,7 @@ most common way is by adding a file to the `/etc/cron.d/` directory.
 First find the correct command to execute, for example:
 
 ```
-/usr/bin/php /path/to/silverstripe/docroot/framework/cli-script.php dev/cron
+/usr/bin/php /path/to/silverstripe/docroot/vendor/silverstripe/framework/cli-script.php dev/cron
 ```
 
 Then find out which user the webserver is running on, for example `www-data`.
@@ -103,7 +113,7 @@ sudo vim /etc/cron.d/silverstripe-crontask
 The content of that file should be:
 
 ```
-* * * * * www-data /usr/bin/php /path/to/silverstripe/docroot/framework/cli-script.php dev/cron
+* * * * * www-data /usr/bin/php /path/to/silverstripe/docroot/vendor/silverstripe/framework/cli-script.php dev/cron
 ```
 
 This will run every minute as the www-data user and check if there are any
@@ -133,8 +143,9 @@ Some examples:
 
 Example:
 
-```
-public function getSchedule() {
+```php
+public function getSchedule()
+{
     return "0 1 * * *";
 }
 ```
@@ -146,8 +157,9 @@ The `process` method will be executed only when it's time for a task to run
 (according to the getSchedule method). What you do in here is up to you. You can
 either do work in here or for example execute BuildTasks run() methods.
 
-```
-public function process() {
+```php
+public function process()
+{
     $task = FilesystemSyncTask::create();
     $task->run(null);
 }
@@ -158,15 +170,17 @@ CRON Expressions
 
 A CRON expression is a string representing the schedule for a particular command to execute.  The parts of a CRON schedule are as follows:
 
-    *    *    *    *    *    *
-    -    -    -    -    -    -
-    |    |    |    |    |    |
-    |    |    |    |    |    + year [optional]
-    |    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
-    |    |    |    +---------- month (1 - 12)
-    |    |    +--------------- day of month (1 - 31)
-    |    +-------------------- hour (0 - 23)
-    +------------------------- min (0 - 59)
+```
+*    *    *    *    *    *
+-    -    -    -    -    -
+|    |    |    |    |    |
+|    |    |    |    |    + year [optional]
+|    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
+|    |    |    +---------- month (1 - 12)
+|    |    +--------------- day of month (1 - 31)
+|    +-------------------- hour (0 - 23)
++------------------------- min (0 - 59)
+```
 
 For more information about what cron expression is allowed, see the
 [Cron-Expression](http://mtdowling.com/blog/2012/06/03/cron-expressions-in-php/)

--- a/_config.php
+++ b/_config.php
@@ -1,5 +1,0 @@
-<?php
-
-if (!defined('CRONTASK_MODULE_PATH')) {
-    define('CRONTASK_MODULE_PATH', dirname(__DIR__));
-}

--- a/_config/crontask.yml
+++ b/_config/crontask.yml
@@ -1,6 +1,13 @@
 ---
 Name: crontask
 ---
+SilverStripe\Dev\DevelopmentAdmin:
+  registered_controllers:
+    cron:
+      controller: SilverStripe\CronTask\Controllers\CronTaskController
+      links:
+        cron: 'Run registered SilverStripe cron tasks'
+
 SilverStripe\Control\Director:
   rules:
-    'dev/cron/$Action': 'SilverStripe\CronTask\Controllers\CronTaskController'
+    'dev/cron/$Action': SilverStripe\CronTask\Controllers\CronTaskController

--- a/src/Controllers/CronTaskController.php
+++ b/src/Controllers/CronTaskController.php
@@ -4,11 +4,13 @@ namespace SilverStripe\CronTask\Controllers;
 
 use Cron\CronExpression;
 use DateTime;
+use Exception;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Convert;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\CronTask\CronTaskStatus;
 use SilverStripe\CronTask\Interfaces\CronTask;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -98,11 +100,11 @@ class CronTaskController extends Controller
         // Check each task
         $tasks = ClassInfo::implementorsOf(CronTask::class);
         if (empty($tasks)) {
-            $this->output('There are no implementators of CronTask to run');
+            $this->output('There are no implementors of CronTask to run');
             return;
         }
         foreach ($tasks as $subclass) {
-            $task = new $subclass();
+            $task = Injector::inst()->create($subclass);
             $this->runTask($task);
         }
     }


### PR DESCRIPTION
Changes:

* Update readme to use SS4 relevant examples
* Remove \_config.php file as it's not used any more
* Update .gitattributes to include phpunit and CI config
* Use Injector to instantiate new cron tasks