### PR TITLE
FIX Removing reference to non-existant SS_DateTime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist src/ tests/; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs src/ tests/; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2" >
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+    </rule>
+</ruleset>

--- a/src/Controllers/CronTaskController.php
+++ b/src/Controllers/CronTaskController.php
@@ -84,7 +84,6 @@ class CronTaskController extends Controller
         if ($this->getRequest()->getVar('debug')) {
             $this->setVerbosity(2);
         }
-
     }
 
     /**

--- a/tests/CronTaskControllerTest.php
+++ b/tests/CronTaskControllerTest.php
@@ -3,11 +3,11 @@
 namespace SilverStripe\CronTask\Tests;
 
 use Cron\CronExpression;
-use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\CronTask\Controllers\CronTask;
 use SilverStripe\CronTask\Controllers\CronTaskController;
 use SilverStripe\CronTask\CronTaskStatus;
-use SilverStripe\CronTask\Controllers\CronTask;
 use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\ORM\FieldType\DBDatetime;
 
 /**
  * @package crontask
@@ -112,7 +112,7 @@ class CronTaskControllerTest extends FunctionalTest
     public function testDefaultQuietFlagOutput()
     {
         $this->loginWithPermission('ADMIN');
-        $this->expectOutputRegex('#'.SS_Datetime::now()->Format('Y-m-d').'#');
+        $this->expectOutputRegex('#' . DBDatetime::now()->Format('Y-m-d') . '#');
         $this->get('dev/cron?debug=1');
     }
 

--- a/tests/CronTaskControllerTest.php
+++ b/tests/CronTaskControllerTest.php
@@ -123,5 +123,4 @@ class CronTaskControllerTest extends FunctionalTest
         $this->expectOutputString('');
         $this->get('dev/cron?quiet=1');
     }
-
 }


### PR DESCRIPTION
Tests are broken because this class doesn't exist. Tests should pass after this 🙂 